### PR TITLE
overwrite mapping; add get mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 build
 builddir
+.idea
 .vscode
 __pycache__
+*.snap
+prime

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ braus --set http://other.fancy chromium_chromium.desktop
 braus --set http://my-videos.org google-chrome.desktop
 ````
 
+Existing URLs will be overwritten with new `--set` calls.
+
+You can see current mappings by
+```
+braus --get-mappings
+```
+
 If you made a mistake, clear the auto mapping list by
 ```
 braus --clear

--- a/src/browser_mappings.py
+++ b/src/browser_mappings.py
@@ -5,37 +5,39 @@ class BrowserMappings():
         self.settings = settings
 
     def do_setbrowser(self, url, browser):
-        mappingsArr = self.do_loadUrlMappings()
-        mappingsArr.append(url + " " + browser)
+        mappingsDict = self.do_loadUrlMappings()
+        mappingsDict[url] = browser
+
+        mappingsArr = []
+        for url, browser in mappingsDict.items():
+            mappingsArr.append(url + " " + browser)
 
         tmpVariant = GLib.Variant('aas', mappingsArr)
         self.settings.set_value("url-mapping", tmpVariant)
 
     def do_clearbrowsermappings(self):
-        mappingsArr=[]
-        tmpVariant = GLib.Variant('aas', mappingsArr)
-        self.settings.set_value("url-mapping", tmpVariant)
-    
+        emptyVariant = GLib.Variant('aas', [])
+        self.settings.set_value("url-mapping", emptyVariant)
+
     def do_loadUrlMappings(self):
         urlMappings = self.settings.get_value("url-mapping")
-        mappingsArr = []
-        for mapping in urlMappings:
-            pathToMatch = "".join(mapping)
-            mappingsArr.append(pathToMatch)
+        mappingsDict = {}
 
-        return mappingsArr
+        for mapping in urlMappings:
+            pathToMatch = "".join(mapping).split(" ")
+            mappingsDict[pathToMatch[0]] = pathToMatch[1]
+
+        return mappingsDict
     
     def do_determinebrowser(self, app, url, browsers):
-        mappingsArr = self.do_loadUrlMappings()
+        mappingsDict = self.do_loadUrlMappings()
 
-        for mapping in mappingsArr:
-            matcher = mapping.split(" ")
-
-            if(not url.startswith(matcher[0])):
+        for urlPattern, browserID in mappingsDict.items():
+            if(not url.startswith(urlPattern)):
                 continue
 
-            for browser in browsers:
-                if(browser.get_id() != matcher[1]):
+            for b in browsers:
+                if(b.get_id() != browserID):
                     continue
-                return browser
+                return b
                         

--- a/src/main.py
+++ b/src/main.py
@@ -65,17 +65,26 @@ class Application(Gtk.Application):
 
     def do_command_line(self, command_line):
         args = command_line.get_arguments()
-        try:
-            if(len(args)> 0):
-                if(args[1] =='--set'):
-                    url = args[2]
-                    browser = args[3]
-                    self.browser_mappings.do_setbrowser(url, browser)
-                    return 0
+        if len(args)== 0:
+            self.activate()
 
-                if(args[1] =='--clear'):
-                    self.browser_mappings.do_clearbrowsermappings()
-                    return 0
+        try:
+            if(args[1] =='--set'):
+                url = args[2]
+                browser = args[3]
+                self.browser_mappings.do_setbrowser(url, browser)
+                return 0
+
+            if(args[1] =='--clear'):
+                self.browser_mappings.do_clearbrowsermappings()
+                return 0
+
+            if(args[1] =='--get-mappings'):
+                mappings = self.browser_mappings.do_loadUrlMappings()
+                for url, browser in mappings.items():
+                    print(url, ":", browser)
+                return 0
+
         except IndexError:
             print("No arguments provided")
 


### PR DESCRIPTION
I've added a new option `--get-mappings` and also implement overwrite functionality. It is a pity when you set wrong browser and instead of overwriting it need to clean all your bindings and start from scratch. Especially when you can't see all existing bindings.